### PR TITLE
Alignment checking

### DIFF
--- a/bin/R3BackupFiles.py
+++ b/bin/R3BackupFiles.py
@@ -1,6 +1,6 @@
 import argparse as ap
-from rach3datautils.extra.backup_files import backup_dir
 
+from rach3datautils.extra.backup_files import backup_dir
 
 parser = ap.ArgumentParser(
     description="Script for syncing two directories"

--- a/bin/R3CheckHash.py
+++ b/bin/R3CheckHash.py
@@ -1,6 +1,6 @@
-from rach3datautils.extra.hashing import check_hashes
 import argparse as ap
 
+from rach3datautils.extra.hashing import check_hashes
 
 if __name__ == "__main__":
     parser = ap.ArgumentParser(

--- a/bin/R3GetVideoHash
+++ b/bin/R3GetVideoHash
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import numpy as np
-from typing import Dict
 import re
+from typing import Dict
+
+import numpy as np
+
 from rach3datautils.extra.hashing import get_video_hash
 from rach3datautils.types import PathLike
-
 
 vname_pat = re.compile(
     "([A-Za-z]+)_([0-9]{4})-([0-9]{2})-([0-9]{2})_w([0-9]{2})_([A-Za-z]+)_v"

--- a/bin/alignment/R3CheckIntegrity.py
+++ b/bin/alignment/R3CheckIntegrity.py
@@ -1,14 +1,13 @@
 import argparse as ap
+import csv
 import os
 from typing import List, Tuple
-import csv
 
 from tqdm import tqdm
 
 from rach3datautils.alignment.verification import Verify
 from rach3datautils.utils.dataset import DatasetUtils
 from rach3datautils.utils.session import Session
-
 
 parser = ap.ArgumentParser(
     prog="R3CheckIntegrity",

--- a/bin/alignment/R3CheckIntegrity.py
+++ b/bin/alignment/R3CheckIntegrity.py
@@ -1,0 +1,62 @@
+import argparse as ap
+from typing import List, Tuple
+import csv
+
+from tqdm import tqdm
+
+from rach3datautils.alignment.verification import Verify
+from rach3datautils.utils.dataset import DatasetUtils
+from rach3datautils.utils.session import Session
+
+parser = ap.ArgumentParser(
+    prog="R3CheckIntegrity",
+    description="Check the integrity of synced files and optionally output "
+                "to a CSV."
+)
+parser.add_argument(
+    "-d", "--root-dir",
+    help="Directory containing files to be checked",
+    type=str,
+    required=True
+)
+parser.add_argument(
+    "-o", "--output-filepath",
+    help="Where to output the csv containing results. If no output is given "
+         "results are printed to stdout.",
+    required=False,
+    type=str
+)
+args = parser.parse_args()
+
+dataset = DatasetUtils(root_path=args.root_dir)
+sessions = dataset.get_sessions(filetype=[".mp4", ".flac"])
+sessions = dataset.remove_noncomplete(sessions, required=["flac.splits_list",
+                                                          "video.splits_list"])
+
+# (session_id, video_path, flac_path, issue)
+invalid_session_list: List[Tuple[str, str, str, str]] = []
+
+for session in tqdm(sessions):
+    session.sort_audios()
+    session.sort_videos()
+
+    for video_split, flac_split in zip(session.video.splits_list,
+                                       session.flac.splits_list):
+        integrity = Verify().check_video_flac(
+            video=video_split,
+            flac=flac_split
+        )
+        if integrity is not True:
+            invalid_session_list.append((str(session.id),
+                                         video_split,
+                                         flac_split,
+                                         integrity))
+
+if args.output_filepath:
+    with open(args.output_filepath, "w") as f:
+        csv_writer = csv.writer(f)
+        csv_writer.writerow(["session_id", "video_path", "flac_path", "issue"])
+        csv_writer.writerows(invalid_session_list)
+else:
+    print("session_id, video_path, flac_path\n")
+    [print(i) for i in invalid_session_list]

--- a/bin/alignment/R3CheckIntegrity.py
+++ b/bin/alignment/R3CheckIntegrity.py
@@ -29,9 +29,10 @@ parser.add_argument(
 args = parser.parse_args()
 
 dataset = DatasetUtils(root_path=args.root_dir)
-sessions = dataset.get_sessions(filetype=[".mp4", ".flac"])
+sessions = dataset.get_sessions(filetype=[".mp4", ".flac", ".mid"])
 sessions = dataset.remove_noncomplete(sessions, required=["flac.splits_list",
-                                                          "video.splits_list"])
+                                                          "video.splits_list",
+                                                          "midi.splits_list"])
 
 # (session_id, video_path, flac_path, issue)
 invalid_session_list: List[Tuple[str, str, str, str]] = []
@@ -40,11 +41,13 @@ for session in tqdm(sessions):
     session.sort_audios()
     session.sort_videos()
 
-    for video_split, flac_split in zip(session.video.splits_list,
-                                       session.flac.splits_list):
-        integrity = Verify().check_video_flac(
+    for video_split, flac_split, midi_split in zip(session.video.splits_list,
+                                                   session.flac.splits_list,
+                                                   session.midi.splits_list):
+        integrity = Verify().run_checks(
             video=video_split,
-            flac=flac_split
+            flac=flac_split,
+            midi=midi_split
         )
         if integrity is not True:
             invalid_session_list.append((str(session.id),

--- a/bin/alignment/R3ExtractConcat.py
+++ b/bin/alignment/R3ExtractConcat.py
@@ -1,11 +1,12 @@
 import argparse
-from rach3datautils.utils.dataset import DatasetUtils
 import os
-from typing import Literal
-from rach3datautils.alignment.extract_and_concat import extract_and_concat
 from pathlib import Path
+from typing import Literal
+
 from tqdm import tqdm
 
+from rach3datautils.alignment.extract_and_concat import extract_and_concat
+from rach3datautils.utils.dataset import DatasetUtils
 
 parser = argparse.ArgumentParser(
     prog="Extract audio/video and concatenate",

--- a/bin/alignment/R3FullPipeline.py
+++ b/bin/alignment/R3FullPipeline.py
@@ -2,15 +2,16 @@
 Script that handles full preprocessing of Rach3 dataset for use with ML.
 """
 
-from pathlib import Path
 import argparse as ap
 import os
-from tqdm import tqdm
-from rach3datautils.utils.dataset import DatasetUtils
 import tempfile
+from pathlib import Path
+
+from tqdm import tqdm
+
 from rach3datautils.alignment.extract_and_concat import extract_and_concat
 from rach3datautils.alignment.split import split_video_flac_mid
-
+from rach3datautils.utils.dataset import DatasetUtils
 
 parser = ap.ArgumentParser(
     prog="Audio Alignment Pipeline",

--- a/bin/alignment/R3FullPipeline.py
+++ b/bin/alignment/R3FullPipeline.py
@@ -23,7 +23,8 @@ parser.add_argument(
     action='store',
     help='The root directory where the dataset is located. All folders '
          'and subfolders in this directory will be searched.',
-    nargs="*"
+    nargs="*",
+    required=True
 )
 parser.add_argument(
     "-w", "--overwrite",

--- a/bin/alignment/R3GetSyncTimes.py
+++ b/bin/alignment/R3GetSyncTimes.py
@@ -1,12 +1,13 @@
 import argparse as ap
-from rach3datautils.utils.dataset import DatasetUtils
-from rach3datautils.alignment.sync import load_and_sync, Sync
-from rach3datautils.types import timestamps
+import csv
 from pathlib import Path
 from typing import List, Tuple
-from tqdm import tqdm
-import csv
 
+from tqdm import tqdm
+
+from rach3datautils.alignment.sync import load_and_sync, Sync
+from rach3datautils.types import timestamps
+from rach3datautils.utils.dataset import DatasetUtils
 
 parser = ap.ArgumentParser(
     prog="Audio Synchronizer",

--- a/bin/alignment/R3SplitVideos.py
+++ b/bin/alignment/R3SplitVideos.py
@@ -1,10 +1,11 @@
 import argparse as ap
-from pathlib import Path
-from tqdm import tqdm
 import os
+from pathlib import Path
+
+from tqdm import tqdm
+
 from rach3datautils.alignment.split import split_video_flac_mid
 from rach3datautils.utils.dataset import DatasetUtils
-
 
 parser = ap.ArgumentParser(
     prog="Midi Based Video and Audio Splitter",

--- a/bin/alignment/R3TrimSilence.py
+++ b/bin/alignment/R3TrimSilence.py
@@ -1,12 +1,13 @@
 import argparse as ap
 from pathlib import Path
-from rach3datautils.utils.dataset import DatasetUtils
-from rach3datautils.utils.session import Session
-from rach3datautils.alignment.trim_silence import trim
-from rach3datautils.exceptions import MissingFilesError
 from typing import List
+
 from tqdm import tqdm
 
+from rach3datautils.alignment.trim_silence import trim
+from rach3datautils.exceptions import MissingFilesError
+from rach3datautils.utils.dataset import DatasetUtils
+from rach3datautils.utils.session import Session
 
 parser = ap.ArgumentParser(
     prog="Silence Trimmer",

--- a/rach3datautils/alignment/extract_and_concat.py
+++ b/rach3datautils/alignment/extract_and_concat.py
@@ -1,9 +1,10 @@
 import tempfile
+from pathlib import Path
 from typing import Optional, List
+
+from rach3datautils.exceptions import MissingFilesError
 from rach3datautils.utils.multimedia import MultimediaTools
 from rach3datautils.utils.session import Session
-from rach3datautils.exceptions import MissingFilesError
-from pathlib import Path
 
 
 def extract_and_concat(session: Session,

--- a/rach3datautils/alignment/split.py
+++ b/rach3datautils/alignment/split.py
@@ -1,17 +1,17 @@
 import logging
-
-import partitura as pt
-from partitura.performance import Performance
 from pathlib import Path
 from typing import Optional, Union, List, Tuple
-from rach3datautils.exceptions import MissingFilesError, SyncError
-from rach3datautils.utils.multimedia import MultimediaTools
-from rach3datautils.alignment.sync import load_and_sync
-from rach3datautils.types import timestamps, note_sections, PathLike
-from rach3datautils.config import LOGLEVEL
+
 import numpy as np
 import numpy.typing as npt
+import partitura as pt
+from partitura.performance import Performance
 
+from rach3datautils.alignment.sync import load_and_sync
+from rach3datautils.config import LOGLEVEL
+from rach3datautils.exceptions import MissingFilesError, SyncError
+from rach3datautils.types import timestamps, note_sections, PathLike
+from rach3datautils.utils.multimedia import MultimediaTools
 
 logger = logging.getLogger(__name__)
 logger.setLevel(LOGLEVEL)

--- a/rach3datautils/alignment/split.py
+++ b/rach3datautils/alignment/split.py
@@ -202,7 +202,7 @@ class Splits:
             start_time = prev_time + start_note
 
             end_note = note_array['onset_sec'][i[1]] - \
-                       note_array['onset_sec'][prev_note]
+                note_array['onset_sec'][prev_note]
             end_time = prev_time + end_note
 
             try:
@@ -423,7 +423,7 @@ def split_va_at_timestamps(splits: List[timestamps],
     """
     for split_no, (start, end) in enumerate(splits):
         output_path_video = output_dir.joinpath(
-            file.stem + f"_split{split_no + 1}" + file.suffix
+            "rach3_" + file.stem + f"_split{split_no + 1}" + file.suffix
         )
 
         if output_path_video.exists() and not overwrite:

--- a/rach3datautils/alignment/split.py
+++ b/rach3datautils/alignment/split.py
@@ -268,7 +268,7 @@ class Splits:
         """
         Check the lengths of sections to make sure they are within the limits
         set by max_section_len and min_section_len.
-        These limits are set when initializing the object.
+        These limits are set as class attributes.
 
         Parameters
         ----------
@@ -317,11 +317,17 @@ class Splits:
                     note_array["onset_sec"][prev_note]
         sect_len = end_note - prev_note
         if sect_time > self.max_section_size:
+            sections = []
             midpoint = prev_note + sect_len // 2
-            sections = [(prev_note, midpoint)]
-            sections.extend(self._check_max_len(note_array,
-                                                midpoint,
-                                                end_note))
+            new_sections_left = self._check_max_len(note_array,
+                                                    prev_note,
+                                                    midpoint)
+            sections.extend(new_sections_left)
+
+            new_sections_right = self._check_max_len(note_array,
+                                                     midpoint,
+                                                     end_note)
+            sections.extend(new_sections_right)
         else:
             return [(prev_note, end_note)]
         return sections

--- a/rach3datautils/alignment/sync.py
+++ b/rach3datautils/alignment/sync.py
@@ -1,14 +1,15 @@
+from typing import Tuple, Optional, TypedDict
+
 import madmom
-from madmom.audio.signal import FramedSignal
-from rach3datautils.exceptions import MissingFilesError
 import numpy as np
 import numpy.typing as npt
-from typing import Tuple, Optional, TypedDict
-from rach3datautils.types import PathLike
 import scipy.spatial as sp
+from madmom.audio.signal import FramedSignal
 from partitura.performance import Performance
-from rach3datautils.exceptions import SyncError
 
+from rach3datautils.exceptions import MissingFilesError
+from rach3datautils.exceptions import SyncError
+from rach3datautils.types import PathLike
 
 # (session ID, first note, last note)
 time_section = Tuple[float, float]

--- a/rach3datautils/alignment/sync.py
+++ b/rach3datautils/alignment/sync.py
@@ -1,200 +1,26 @@
-from typing import Tuple, Optional, TypedDict
+from typing import Tuple, Optional, TypedDict, Callable
 
-import madmom
 import numpy as np
 import numpy.typing as npt
 import scipy.spatial as sp
-from madmom.audio.signal import FramedSignal
 from partitura.performance import Performance
 
 from rach3datautils.exceptions import MissingFilesError
 from rach3datautils.exceptions import SyncError
-from rach3datautils.types import PathLike
+from rach3datautils.types import PathLike, timestamps
+from rach3datautils.utils.track import Track, TrackArgs
 
-# (session ID, first note, last note)
-time_section = Tuple[float, float]
-timestamps = Tuple[str, time_section]
+# A tuple with start and end frame
 frame_section = Tuple[int, int]
 
 
-# These TypedDicts are useful for specifying inputs to the load_and_sync func.
-class TrackArgs(TypedDict, total=False):
-    frame_size: Optional[int]
-    sample_rate: Optional[int]
-    hop_size: Optional[float]
-
-
+# This TypedDict is useful for specifying inputs to the load_and_sync func.
 class SyncArgs(TypedDict, total=False):
     notes_index: Optional[Tuple[int, int]]
     window_size: Optional[int]
     stride: Optional[int]
     search_period: Optional[int]
-    start_end_times: Optional[time_section]
-
-
-class Track:
-    """
-    Class for a single track, to be used in the Sync class when representing
-    the two tracks being synced.
-    """
-    FRAME_SIZE = 8372
-    SAMPLE_RATE = 44100
-    HOP_SIZE = int(np.round(SAMPLE_RATE * 0.025))
-
-    def __init__(self,
-                 filepath: PathLike,
-                 frame_size: Optional[int] = None,
-                 sample_rate: Optional[int] = None,
-                 hop_size: Optional[float] = None):
-        """
-        Parameters
-        ----------
-        filepath : PathLike
-            path to the track including filename
-        frame_size : int, optional
-            track frame size to use when loading, default: 8372
-        sample_rate : int, optional
-            sample rate to be used when loading, default: 44100
-        hop_size : float, optional
-            essentially the resolution, default: 1102
-        """
-        if frame_size is None:
-            frame_size = self.FRAME_SIZE
-        if sample_rate is None:
-            sample_rate = self.SAMPLE_RATE
-        if hop_size is None:
-            hop_size = self.HOP_SIZE
-
-        self.hop_size = hop_size
-        self.sample_rate = sample_rate
-
-        self.signal: FramedSignal = self.load_framed_signal(
-            filepath=filepath,
-            frame_size=frame_size,
-            hop_size=hop_size,
-            sample_rate=sample_rate
-        )
-        self.frame_times: npt.NDArray = self.calc_frame_times()
-
-    def getframe(self, time: float) -> int:
-        """
-        Get the closest frame to a certain timestamp is seconds. Inverse of
-        gettime.
-
-        Parameters
-        ----------
-        time : float
-            timestamp in seconds
-
-        Returns
-        -------
-        frame : int
-            the frame index closest to the time given
-        """
-        return abs((self.frame_times - time)).argmin()
-
-    def calc_frame_times(self) -> npt.NDArray:
-        """
-        Calculate the frame times of the signal.
-
-        Returns
-        -------
-        frame_times : npt.NDArray
-            has an index for every frame at which you can see the time
-        """
-        return np.arange(
-            self.signal.shape[0]
-        ) * (self.hop_size / self.sample_rate)
-
-    @staticmethod
-    def load_framed_signal(filepath: PathLike,
-                           frame_size: int,
-                           hop_size: int,
-                           sample_rate: int) -> FramedSignal:
-        """
-        Load a file into a signal.
-
-        Parameters
-        ----------
-        filepath : PathLike
-            path to audio file
-        frame_size : int
-            frame size to use when loading the Signal
-        hop_size : int
-            hop size to use when loading the FramedSignal
-        sample_rate : int
-            sample rate to use when loading the Signal
-
-        Returns
-        -------
-        framed_signal : FramedSignal
-        """
-        signal = madmom.audio.Signal(
-            str(filepath),
-            sample_rate=sample_rate,
-            num_channels=1,
-            norm=True,
-        )
-        f_signal = madmom.audio.FramedSignal(
-            signal=signal,
-            frame_size=frame_size,
-            hop_size=hop_size
-        )
-
-        return f_signal
-
-    def calc_log_spect_section(
-            self,
-            start: Optional[float] = None,
-            end: Optional[float] = None,
-            spectrogram_clip: Optional[Tuple[int, int]] = None
-    ) -> Tuple[time_section, npt.NDArray]:
-        """
-        Generate a certain section of the log_spectrogram given start and end
-        points.
-        Uses the logarithmic filtered spectrogram by default.
-        If start/end points are none then the entire signal is used.
-
-        spectrogram_clip specifies the start and end of the frequency bands
-        index, useful for reducing ram usage and improving performance if you
-        don't need the whole range of frequency bands.
-
-        Parameters
-        ----------
-        start : float, optional
-            start time in seconds
-        end : float, optional
-            end time in seconds
-        spectrogram_clip : Tuple[int, int], optional
-            tuple of indexes. Frequency bands within these
-            indexes will be kept.
-
-        Returns
-        -------
-        start_end_spectrogram : Tuple[time_section, npt.NDArray]
-            exact start and end times of spectrogram, spectrogram
-        """
-        if start is None:
-            start = 0
-        if end is None:
-            end = self.signal.shape[0]
-        if spectrogram_clip is None:
-            spectrogram_clip = (10, 40)
-
-        start = self.getframe(start)
-        end = self.getframe(end)
-
-        if end - start <= 0:
-            raise AttributeError("The given end should be larger than the "
-                                 "start.")
-
-        spec = np.array(
-            madmom.audio.LogarithmicFilteredSpectrogram(
-                self.signal[start:end][:]
-            )
-        )[:, spectrogram_clip[0]:spectrogram_clip[1]]
-
-        return (self.frame_times[start], self.frame_times[end]), spec
+    start_end_times: Optional[timestamps]
 
 
 class Sync:
@@ -231,8 +57,8 @@ class Sync:
                         window_size: Optional[int] = None,
                         stride: Optional[int] = None,
                         search_period: Optional[int] = None,
-                        start_end_times: Optional[time_section] = None
-                        ) -> time_section:
+                        start_end_times: Optional[timestamps] = None
+                        ) -> timestamps:
         """
         Get the timestamps for the first and last note given 2 audio files and
         a midi file.
@@ -353,7 +179,7 @@ class Sync:
                                track: Track,
                                section_size: float,
                                section_midpoint: float,
-                               ) -> Tuple[time_section, npt.NDArray]:
+                               ) -> Tuple[timestamps, npt.NDArray]:
         """
         Generate windows within 2 given boundaries. Returns the windows and
         the start and end points of the boundaries.
@@ -442,8 +268,8 @@ def load_and_sync(
         audio: PathLike,
         track_args: Optional[TrackArgs] = None,
         sync_args: Optional[SyncArgs] = None,
-        sync_distance_func: Optional = None
-) -> time_section:
+        sync_distance_func: Optional[Callable] = None
+) -> timestamps:
     """
     Function that handles loading flac and audio from a subsession and then
     syncing them using the Sync and Track objects respectively.
@@ -460,7 +286,7 @@ def load_and_sync(
         optional args to be passed to the Track object
     sync_args : SyncArgs, optional
         optional args to be passed to the Sync object
-    sync_distance_func : func, optional
+    sync_distance_func : Callable, optional
         optional custom distance function
 
     Returns

--- a/rach3datautils/alignment/trim_silence.py
+++ b/rach3datautils/alignment/trim_silence.py
@@ -1,10 +1,12 @@
 from typing import Optional
-from rach3datautils.utils.multimedia import MultimediaTools
-from rach3datautils.types import PathLike
-from rach3datautils.alignment.sync import load_and_sync
-from rach3datautils.exceptions import MissingFilesError
+
 import numpy as np
 from partitura.performance import Performance
+
+from rach3datautils.alignment.sync import load_and_sync
+from rach3datautils.exceptions import MissingFilesError
+from rach3datautils.types import PathLike
+from rach3datautils.utils.multimedia import MultimediaTools
 
 
 def trim(audio: PathLike,

--- a/rach3datautils/alignment/verification.py
+++ b/rach3datautils/alignment/verification.py
@@ -23,7 +23,7 @@ class Verify:
                    video: PathLike,
                    flac: PathLike,
                    midi: PathLike) -> Union[verification_issues,
-                                               Literal[True]]:
+                                            Literal[True]]:
         """
         Check whether a video and flac file are sufficiently aligned.
 
@@ -47,7 +47,7 @@ class Verify:
             return "incorrect_len"
         elif not self.check_tracks(video_track, flac_track):
             return "high_DTW"
-        elif not self.check_midi(midi, flac):
+        elif not self.check_midi(perf, flac):
             return "midi_DTW"
         return True
 

--- a/rach3datautils/alignment/verification.py
+++ b/rach3datautils/alignment/verification.py
@@ -2,14 +2,14 @@ from typing import Literal, Union, Optional, Callable
 
 import numpy as np
 import numpy.typing as npt
-from fastdtw import fastdtw
-from scipy.spatial.distance import cosine
-from partitura.performance import Performance
 import partitura as pt
+from fastdtw import fastdtw
+from partitura.performance import Performance
+from scipy.spatial.distance import cosine
 
 from rach3datautils.types import PathLike
-from rach3datautils.utils.track import Track
 from rach3datautils.utils.multimedia import MultimediaTools
+from rach3datautils.utils.track import Track
 
 verification_issues = Literal["incorrect_len", "high_DTW", "midi_DTW"]
 
@@ -22,7 +22,7 @@ class Verify:
     def run_checks(self,
                    video: PathLike,
                    flac: PathLike,
-                   midi: Performance) -> Union[verification_issues,
+                   midi: PathLike) -> Union[verification_issues,
                                                Literal[True]]:
         """
         Check whether a video and flac file are sufficiently aligned.
@@ -100,9 +100,10 @@ class Verify:
 
         if np.abs(duration_t1 - duration_t2) > threshold:
             return False
-        elif np.abs(last_note_mid - duration_t1) > threshold or \
-                np.abs(last_note_mid - duration_t2) > threshold:
-            return False
+        elif last_note_mid > duration_t1 or last_note_mid < duration_t1 - 6:
+            if np.abs(last_note_mid - duration_t1) > threshold or \
+                    np.abs(last_note_mid - duration_t2) > threshold:
+                return False
         return True
 
     def check_tracks(self,
@@ -186,7 +187,7 @@ class Verify:
 
     @staticmethod
     def _calculate_path_norm(path: list[tuple[int, int]],
-                             dims: tuple[int ,int]):
+                             dims: tuple[int, int]):
         """
         Calculate the deviation of a DTW path from the diagonal and normalize
         it.

--- a/rach3datautils/alignment/verification.py
+++ b/rach3datautils/alignment/verification.py
@@ -1,0 +1,126 @@
+from typing import Literal, Union, Optional, Callable
+
+import numpy as np
+import numpy.typing as npt
+from dtw import dtw
+
+from rach3datautils.types import PathLike
+from rach3datautils.utils.track import Track
+
+verification_issues = Literal["incorrect_len", "high_DTW"]
+
+
+class Verify:
+    """
+    Contains modules useful for verifying alignment integrity.
+    """
+
+    def check_video_flac(self,
+                         video: PathLike,
+                         flac: PathLike) -> Union[verification_issues,
+                                                  Literal[True]]:
+        """
+        Check whether a video and flac file are sufficiently aligned.
+
+        Parameters
+        ----------
+        video : PathLike
+        flac : PathLike
+
+        Returns
+        -------
+        result : bool or string
+            True if no issues were found, a string with the issue otherwise
+        """
+
+        video_track = Track(video)
+        flac_track = Track(flac)
+
+        if not self.check_len(video_track, flac_track):
+            return "incorrect_len"
+        elif not self.check_spectrogram(video_track, flac_track):
+            return "high_DTW"
+        return True
+
+    @staticmethod
+    def check_len(track_1: Track,
+                  track_2: Track,
+                  threshold: Optional[float] = None) -> bool:
+        """
+        Compare track lengths using a given threshold.
+
+        Parameters
+        ----------
+        track_1 : Track
+        track_2 : Track
+        threshold : float, optional
+
+        Returns
+        -------
+        bool
+            whether the lengths are close enough according to the threshold
+        """
+        if threshold is None:
+            threshold = 0.5
+
+        if np.abs(track_1.frame_times[-1] -
+                  track_2.frame_times[-1]) > threshold:
+            return False
+        return True
+
+    def check_spectrogram(self,
+                          track_1: Track,
+                          track_2: Track,
+                          dist_func: Optional[Callable] = None,
+                          threshold: Optional[float] = None) -> bool:
+        """
+        Check the distance between two tracks spectrogram's. Additionally,
+        checks whether the two given tracks length is close enough.
+
+        Parameters
+        ----------
+        track_1 : PathLike
+        track_2 : PathLike
+        dist_func : Callable distance function
+            takes two numpy arrays and returns a float
+        threshold : float
+            at what value to say the alignment is not good
+
+        Returns
+        -------
+        bool
+            whether or not the tracks are sufficiently aligned
+        """
+        if dist_func is None:
+            dist_func = self.spec_dtw
+        if threshold is None:
+            threshold = 2
+
+        t1_spec = track_1.calc_log_spect_section()
+        t2_spec = track_2.calc_log_spect_section()
+
+        dist = dist_func(t1_spec[1], t2_spec[1])
+
+        if dist > threshold:
+            return False
+        return True
+
+    @staticmethod
+    def spec_dtw(spec_1: npt.NDArray, spec_2: npt.NDArray) -> float:
+        """
+        Compare two spectrograms using DTW. Returns a number of best fit.
+
+        Parameters
+        ----------
+        spec_1 : numpy array of first spectrogram
+        spec_2 : numpy array of second spectrogram
+
+        Returns
+        -------
+        score : float
+            how close the two spectrograms are to each other
+        """
+        alignment = dtw(spec_1, spec_2)
+        norm_dist: float = alignment.normalizedDistance
+
+        return norm_dist

--- a/rach3datautils/alignment/verification.py
+++ b/rach3datautils/alignment/verification.py
@@ -51,11 +51,24 @@ class Verify:
             return "midi_DTW"
         return True
 
-    def check_midi(self,
-                   midi: Performance,
-                   flac: PathLike) -> Literal[True, "midi_DTW"]:
+    @staticmethod
+    def check_midi(midi: Performance,
+                   flac: PathLike) -> bool:
+        """
+        Check a midi file against a flac file using their spectrogram's and
+        DTW.
+
+        Parameters
+        ----------
+        midi : Performance
+        flac : PathLike
+
+        Returns
+        -------
+        bool
+        """
         # TODO
-        ...
+        return True
 
     @staticmethod
     def check_len(track_1: Track,

--- a/rach3datautils/alignment/verification.py
+++ b/rach3datautils/alignment/verification.py
@@ -2,10 +2,14 @@ from typing import Literal, Union, Optional, Callable
 
 import numpy as np
 import numpy.typing as npt
-from dtw import dtw
+from fastdtw import fastdtw
 from scipy.spatial.distance import cosine
+from partitura.performance import Performance
+import partitura as pt
+
 from rach3datautils.types import PathLike
 from rach3datautils.utils.track import Track
+from rach3datautils.utils.multimedia import MultimediaTools
 
 verification_issues = Literal["incorrect_len", "high_DTW"]
 
@@ -15,11 +19,11 @@ class Verify:
     Contains modules useful for verifying alignment integrity.
     """
 
-    def check_video_flac(self,
-                         video: PathLike,
-                         flac: PathLike,
-                         midi: PathLike = None) -> Union[verification_issues,
-                                                  Literal[True]]:
+    def run_checks(self,
+                   video: PathLike,
+                   flac: PathLike,
+                   midi: PathLike) -> Union[verification_issues,
+                                            Literal[True]]:
         """
         Check whether a video and flac file are sufficiently aligned.
 
@@ -27,6 +31,7 @@ class Verify:
         ----------
         video : PathLike
         flac : PathLike
+        midi: PathLike
 
         Returns
         -------
@@ -36,26 +41,35 @@ class Verify:
 
         video_track = Track(video)
         flac_track = Track(flac)
+        perf = pt.load_performance_midi(midi)
 
-        if not self.check_len(video_track, flac_track, midi):
+        if not self.check_len(video_track, flac_track, perf):
             return "incorrect_len"
-        elif not self.check_spectrogram(video_track, flac_track):
+        elif not self.check_tracks(video_track, flac_track):
             return "high_DTW"
         elif not self.check_midi(midi, flac):
             return "midi_DTW"
         return True
 
+    def check_midi(self,
+                   midi: Performance,
+                   flac: PathLike) -> Literal[True, "midi_DTW"]:
+        # TODO
+        ...
+
     @staticmethod
     def check_len(track_1: Track,
                   track_2: Track,
+                  perf: Performance,
                   threshold: Optional[float] = None) -> bool:
         """
-        Compare track lengths using a given threshold.
+        Compare track and performance lengths using a given threshold.
 
         Parameters
         ----------
         track_1 : Track
         track_2 : Track
+        perf : Performance
         threshold : float, optional
 
         Returns
@@ -66,14 +80,32 @@ class Verify:
         if threshold is None:
             threshold = 0.5
 
-        if np.abs(track_1.frame_times[-1] -
-                  track_2.frame_times[-1]) > threshold:
+        last_note_mid = MultimediaTools.get_last_offset(perf)
+        last_note_t1 = track_1.frame_times[-1]
+        last_note_t2 = track_2.frame_times[-1]
+
+        if np.abs(last_note_t1 - last_note_t2) > threshold:
+            return False
+        elif np.abs(last_note_mid - last_note_t1) > threshold or \
+                np.abs(last_note_mid - last_note_t2) > threshold:
             return False
         return True
 
     def check_tracks(self,
                      track_1,
-                     track_2):
+                     track_2) -> bool:
+        """
+        Check two tracks by comparing their spectrograms with DTW
+
+        Parameters
+        ----------
+        track_1 : Track
+        track_2 : Track
+
+        Returns
+        -------
+        bool
+        """
         t1_spec = track_1.calc_log_spect_section()
         t2_spec = track_2.calc_log_spect_section()
 
@@ -81,8 +113,8 @@ class Verify:
                                       spect_2=t2_spec)
 
     def check_spectrogram(self,
-                          spect_1,
-                          spect_2,
+                          spect_1: npt.NDArray,
+                          spect_2: npt.NDArray,
                           dist_func: Optional[Callable] = None,
                           threshold: Optional[float] = None) -> bool:
         """
@@ -91,8 +123,8 @@ class Verify:
 
         Parameters
         ----------
-        spect_1 : PathLike
-        spect_2 : PathLike
+        spect_1 : npt.NDArray
+        spect_2 : npt.NDArray
         dist_func : Callable distance function
             takes two numpy arrays and returns a float
         threshold : float
@@ -117,7 +149,7 @@ class Verify:
     @staticmethod
     def spec_dtw(spec_1: npt.NDArray, spec_2: npt.NDArray) -> float:
         """
-        Compare two spectrograms using DTW. Returns a number of best fit.
+        Compare two spectrograms using DTW. Returns the normalized distance.
 
         Parameters
         ----------
@@ -129,7 +161,9 @@ class Verify:
         score : float
             how close the two spectrograms are to each other
         """
-        alignment = dtw(spec_1, spec_2, dist_method=cosine)
-        norm_dist: float = alignment.normalizedDistance
+        spec_1_norm = (spec_1-np.min(spec_1))/(np.max(spec_1)-np.min(spec_1))
+        spec_2_norm = (spec_2-np.min(spec_2))/(np.max(spec_2)-np.min(spec_2))
 
-        return norm_dist
+        dist, path = fastdtw(spec_1_norm, spec_2_norm, dist=cosine)
+        dist_norm = 1 - dist
+        return dist_norm

--- a/rach3datautils/alignment/verification.py
+++ b/rach3datautils/alignment/verification.py
@@ -95,13 +95,13 @@ class Verify:
             threshold = 0.5
 
         last_note_mid = MultimediaTools.get_last_offset(perf)
-        last_note_t1 = track_1.frame_times[-1]
-        last_note_t2 = track_2.frame_times[-1]
+        duration_t1 = track_1.duration
+        duration_t2 = track_2.duration
 
-        if np.abs(last_note_t1 - last_note_t2) > threshold:
+        if np.abs(duration_t1 - duration_t2) > threshold:
             return False
-        elif np.abs(last_note_mid - last_note_t1) > threshold or \
-                np.abs(last_note_mid - last_note_t2) > threshold:
+        elif np.abs(last_note_mid - duration_t1) > threshold or \
+                np.abs(last_note_mid - duration_t2) > threshold:
             return False
         return True
 

--- a/rach3datautils/config.py
+++ b/rach3datautils/config.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError:
     pass
 
 LOGLEVELS = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
-LOGLEVEL: Union[LOGLEVELS, str] = os.getenv("RACH3DATAUTILS_LOGLEVEL", "INFO")
+LOGLEVEL: Union[LOGLEVELS, str] = os.getenv("RACH3DATAUTILS_LOGLEVEL", "ERROR")
 
 logging.basicConfig(level=LOGLEVEL)
 logger = logging.getLogger("rach3datautils")

--- a/rach3datautils/extra/backup_files.py
+++ b/rach3datautils/extra/backup_files.py
@@ -1,10 +1,11 @@
-import os
-import filecmp
 import datetime
+import filecmp
+import os
+from pathlib import Path
+from typing import Optional
+
 from rach3datautils.types import PathLike
 from rach3datautils.utils.path import PathUtils
-from typing import Optional
-from pathlib import Path
 
 
 def backup_dir(

--- a/rach3datautils/extra/ctime.py
+++ b/rach3datautils/extra/ctime.py
@@ -1,7 +1,9 @@
 import datetime
-import filedate
-from rach3datautils.types import PathLike
 from typing import Union
+
+import filedate
+
+from rach3datautils.types import PathLike
 
 
 def change_creation_time(

--- a/rach3datautils/extra/hashing.py
+++ b/rach3datautils/extra/hashing.py
@@ -1,15 +1,17 @@
 """
 Miscellaneous utilities
 """
-import subprocess
+import glob
 import hashlib
+import os
 import platform
-from rach3datautils.types import PathLike
+import subprocess
 from typing import Union, List
+
 import numpy as np
 from tqdm import tqdm
-import glob
-import os
+
+from rach3datautils.types import PathLike
 
 
 class Hashing:

--- a/rach3datautils/types.py
+++ b/rach3datautils/types.py
@@ -1,9 +1,8 @@
 """
 Custom types used throughout the whole module
 """
-from typing import Tuple, Union
 import os
-
+from typing import Tuple, Union
 
 timestamps = Tuple[float, float]
 note_sections = Tuple[int, int]

--- a/rach3datautils/utils/dataset.py
+++ b/rach3datautils/utils/dataset.py
@@ -1,11 +1,11 @@
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 from typing import Union, Literal, List, Optional
-from rach3datautils.utils.session import Session, SessionIdentity
-from rach3datautils.utils.path import PathUtils, suffixes_list, suffixes
-from rach3datautils.types import PathLike
-from rach3datautils.exceptions import IdentityError
 
+from rach3datautils.exceptions import IdentityError
+from rach3datautils.types import PathLike
+from rach3datautils.utils.path import PathUtils, suffixes_list, suffixes
+from rach3datautils.utils.session import Session, SessionIdentity
 
 valid_input_filetypes = Union[list[suffixes], suffixes, Literal["*"]]
 

--- a/rach3datautils/utils/multimedia.py
+++ b/rach3datautils/utils/multimedia.py
@@ -248,11 +248,8 @@ class MultimediaTools:
         -------
         last_offset : float
         """
-        return max([i["note_off"] for i in performance[0].notes])
-        # For some reason, using the note array gives incorrect times. I'll
-        # leave the code here for now and perhaps it gets fixed in the future.
-        # note_array = performance.note_array()
-        # return max(note_array["onset_sec"] + note_array["duration_sec"])
+        note_array = performance.note_array()
+        return max(note_array["onset_sec"] + note_array["duration_sec"])
 
     @staticmethod
     def split_audio(audio_path: PathLike,

--- a/rach3datautils/utils/multimedia.py
+++ b/rach3datautils/utils/multimedia.py
@@ -446,9 +446,17 @@ class MultimediaTools:
         ffmpeg_return = out.run(capture_stderr=True)[1]
 
         # Parsing the output to get the time
-        encode_out = ffmpeg_return.split(b"\n")[46].split(b"\r")
-        encode_sub = encode_out[-1].split(b" ")
-        encode_sub.reverse()
+        split_return = ffmpeg_return.split(b"\n")
+        encode_sub = None
+        for i in split_return:
+            if i[:5] == b"size=":
+                encode_sub = i.split(b"\r")[-1].split(b" ")
+                encode_sub.reverse()
+                break
+
+        if encode_sub is None:
+            raise AttributeError("Could not parse the file.")
+
         time = []
         for i in encode_sub:
             if b"time=" in i:

--- a/rach3datautils/utils/multimedia.py
+++ b/rach3datautils/utils/multimedia.py
@@ -236,6 +236,22 @@ class MultimediaTools:
         return note_array[-1][0]
 
     @staticmethod
+    def get_last_offset(performance: Performance):
+        """
+        Last note in note array + duration of that note
+
+        Parameters
+        ----------
+        performance : Performance
+
+        Returns
+        -------
+        last_offset : float
+        """
+        note_array = performance.note_array()
+        return note_array["onset_sec"][-1] + note_array["duration_sec"][-1]
+
+    @staticmethod
     def split_audio(audio_path: PathLike,
                     split_start: float,
                     split_end: float,

--- a/rach3datautils/utils/multimedia.py
+++ b/rach3datautils/utils/multimedia.py
@@ -509,7 +509,9 @@ class MultimediaTools:
                 slice_ppart_by_time(
                     ppart=performed_part,
                     start_time=i[0],
-                    end_time=i[1]
+                    end_time=i[1],
+                    clip_note_off=True,
+                    reindex_notes=True
                 )
             )
         return subperformances

--- a/rach3datautils/utils/multimedia.py
+++ b/rach3datautils/utils/multimedia.py
@@ -1,17 +1,18 @@
-import warnings
-from typing import Optional, Union, overload, Literal, List
-import shutil
-from pathlib import Path
 import os
+import shutil
 import tempfile
+import warnings
+from pathlib import Path
+from typing import Optional, Union, overload, Literal, List
+
 import ffmpeg
 import partitura as pt
-from partitura.utils.music import slice_ppart_by_time
-from partitura.performance import PerformedPart
 from partitura.performance import Performance
-from rach3datautils.types import PathLike, timestamps
-from rach3datautils.config import LOGLEVEL
+from partitura.performance import PerformedPart
+from partitura.utils.music import slice_ppart_by_time
 
+from rach3datautils.config import LOGLEVEL
+from rach3datautils.types import PathLike, timestamps
 
 FFMPEG_LOGLEVELS = {
     "DEBUG": "debug",

--- a/rach3datautils/utils/path.py
+++ b/rach3datautils/utils/path.py
@@ -1,8 +1,8 @@
+import re
 from pathlib import Path
 from typing import Union, Literal, Tuple, get_args, List
-import re
-from rach3datautils.exceptions import IdentityError
 
+from rach3datautils.exceptions import IdentityError
 
 filetypes = Literal["midi", "full_midi", "flac", "full_flac", "mp4",
                     "full_video", "video", "aac", "full_audio", "audio",

--- a/rach3datautils/utils/session.py
+++ b/rach3datautils/utils/session.py
@@ -308,6 +308,7 @@ class Session:
         if midi_filepath is None:
             return
         self._performance = MultimediaTools.load_performance(midi_filepath)
+        self._performance[0].sustain_pedal_threshold = 127
 
     def set_unknown(self, value: Union[PathLike, list[PathLike]]) -> bool:
         """

--- a/rach3datautils/utils/session.py
+++ b/rach3datautils/utils/session.py
@@ -144,6 +144,13 @@ class SessionFile:
 
     @property
     def splits_list(self) -> List[Optional[Path]]:
+        """
+        List of files that make up the original file after its been split.
+
+        Returns
+        -------
+        splits_list : List[Optional[Path]]
+        """
         return self._splits_list
 
     @splits_list.setter
@@ -152,6 +159,13 @@ class SessionFile:
 
     @property
     def file_list(self) -> List[Optional[Path]]:
+        """
+        The list of files that represent one large recording.
+
+        Returns
+        -------
+        file_list : List[Optional[Path]]
+        """
         return self._file_list
 
     @file_list.setter
@@ -163,6 +177,13 @@ class SessionFile:
 
     @property
     def file(self) -> Path:
+        """
+        Path to the actual file represented by the object.
+
+        Returns
+        -------
+        file : Path
+        """
         return self._file
 
     @file.setter
@@ -177,6 +198,13 @@ class SessionFile:
 
     @property
     def trimmed(self) -> Path:
+        """
+        Path to the trimmed version of the file.
+
+        Returns
+        -------
+        trimmed_file : Path
+        """
         return self._trimmed
 
     @trimmed.setter
@@ -188,6 +216,20 @@ class SessionFile:
         value = Path(value)
         self.id.check_identity(value)
         self._trimmed = value
+
+    def all_files(self):
+        """
+        Get all files in the SessionFile object.
+
+        Returns
+        -------
+        file_list : List[PathLike]
+        """
+        all_files = [self.file, self.trimmed]
+        all_files.extend(self.splits_list)
+        all_files.extend(self.file_list)
+        files_list = [i for i in all_files if i is not None]
+        return files_list
 
 
 class Session:
@@ -357,3 +399,17 @@ class Session:
             except AttributeError:
                 return False
         return True
+
+    def all_files(self):
+        """
+        Get all the files in the Session object.
+
+        Returns
+        -------
+        file_list : List[Path]
+        """
+        file_list = []
+        for i in [self.audio, self.video, self.midi, self.flac]:
+            file_list.extend(i.all_files())
+
+        return file_list

--- a/rach3datautils/utils/session.py
+++ b/rach3datautils/utils/session.py
@@ -1,10 +1,12 @@
 from pathlib import Path
-from rach3datautils.utils.path import PathUtils
-from rach3datautils.types import PathLike
-from rach3datautils.exceptions import IdentityError
-from rach3datautils.utils.multimedia import MultimediaTools
 from typing import Union, Optional, List, Tuple, Literal
+
 from partitura.performance import Performance
+
+from rach3datautils.exceptions import IdentityError
+from rach3datautils.types import PathLike
+from rach3datautils.utils.multimedia import MultimediaTools
+from rach3datautils.utils.path import PathUtils
 
 full_session_id = Tuple[str, str]  # (date, subsession_no)
 # A file can either be composed of many parts, "multi", or just be one part

--- a/rach3datautils/utils/track.py
+++ b/rach3datautils/utils/track.py
@@ -74,6 +74,17 @@ class Track:
         )
         self.frame_times: npt.NDArray = self.calc_frame_times()
 
+    @property
+    def duration(self) -> float:
+        """
+        Get length of track in seconds.
+
+        Returns
+        -------
+        duration : float
+        """
+        return self.frame_times[-1]
+
     def get_frame(self, time: float) -> int:
         """
         Get the closest frame to a certain timestamp is seconds. Inverse of

--- a/rach3datautils/utils/track.py
+++ b/rach3datautils/utils/track.py
@@ -1,0 +1,203 @@
+from pathlib import Path
+from typing import Optional, TypedDict, Tuple, Union, Dict
+
+import madmom
+import numpy as np
+import numpy.typing as npt
+from madmom.audio.signal import FramedSignal
+
+from rach3datautils.types import PathLike, timestamps
+from rach3datautils.utils.multimedia import MultimediaTools
+
+
+class TrackArgs(TypedDict, total=False):
+    frame_size: Optional[int]
+    sample_rate: Optional[int]
+    hop_size: Optional[float]
+
+
+class Track:
+    """
+    Class for a single audio track. Can take videos as well and will extract
+    their audio when loading into memory.
+    """
+    FRAME_SIZE = 8372
+    SAMPLE_RATE = 44100
+    HOP_SIZE = int(np.round(SAMPLE_RATE * 0.025))
+
+    def __init__(self,
+                 filepath: PathLike,
+                 frame_size: Optional[int] = None,
+                 sample_rate: Optional[int] = None,
+                 hop_size: Optional[float] = None):
+        """
+        Parameters
+        ----------
+        filepath : PathLike
+            path to the audio or video file.
+        frame_size : int, optional
+            track frame size to use when loading, default: 8372
+        sample_rate : int, optional
+            sample rate to be used when loading, default: 44100
+        hop_size : float, optional
+            essentially the resolution, default: 1102
+        """
+        if frame_size is None:
+            frame_size = self.FRAME_SIZE
+        if sample_rate is None:
+            sample_rate = self.SAMPLE_RATE
+        if hop_size is None:
+            hop_size = self.HOP_SIZE
+
+        filepath = Path(filepath)
+
+        if filepath.suffix == ".mp4":
+            data = MultimediaTools().load_file_audio(filepath=filepath,
+                                                     sample_rate=sample_rate)
+        elif filepath.suffix == ".aac":
+            data = filepath
+        elif filepath.suffix == ".flac":
+            data = filepath
+        else:
+            raise AttributeError("Filepath should point to an AAC file or "
+                                 "mp4 file.")
+
+        self.hop_size: int = hop_size
+        self.sample_rate: int = sample_rate
+        self.filepath: PathLike = filepath
+
+        self.signal: FramedSignal = self.load_framed_signal(
+            data=data,
+            frame_size=frame_size,
+            hop_size=hop_size,
+            sample_rate=sample_rate
+        )
+        self.frame_times: npt.NDArray = self.calc_frame_times()
+
+    def get_frame(self, time: float) -> int:
+        """
+        Get the closest frame to a certain timestamp is seconds. Inverse of
+        get_time.
+
+        Parameters
+        ----------
+        time : float
+            timestamp in seconds
+
+        Returns
+        -------
+        frame : int
+            the frame index closest to the time given
+        """
+        return abs((self.frame_times - time)).argmin()
+
+    def calc_frame_times(self) -> npt.NDArray:
+        """
+        Calculate the frame times of the signal.
+
+        Returns
+        -------
+        frame_times : npt.NDArray
+            has an index for every frame at which you can see the time
+        """
+        return np.arange(
+            self.signal.shape[0]
+        ) * (self.hop_size / self.sample_rate)
+
+    @staticmethod
+    def load_framed_signal(data: Union[PathLike, npt.NDArray],
+                           frame_size: int,
+                           hop_size: int,
+                           sample_rate: int,
+                           kwargs: Optional[Dict] = None) -> FramedSignal:
+        """
+        Load a file into a signal.
+
+        Parameters
+        ----------
+        data : Union[PathLike, npt.NDArray]
+            path to audio file or actual audio file data in numpy array.
+        frame_size : int
+            frame size to use when loading the Signal.
+        hop_size : int
+            hop size to use when loading the FramedSignal.
+        sample_rate : int
+            sample rate to use when loading the Signal.
+        kwargs : Dict
+            any additional arguments to be passed to madmom.audio.Signal
+
+        Returns
+        -------
+        framed_signal : FramedSignal
+        """
+        if kwargs is None:
+            kwargs = {}
+        if isinstance(data, Path):
+            data = str(data)
+
+        signal = madmom.audio.Signal(
+            data,
+            sample_rate=sample_rate,
+            num_channels=1,
+            norm=True,
+            **kwargs
+        )
+        f_signal = madmom.audio.FramedSignal(
+            signal=signal,
+            frame_size=frame_size,
+            hop_size=hop_size
+        )
+
+        return f_signal
+
+    def calc_log_spect_section(
+            self,
+            start: Optional[float] = None,
+            end: Optional[float] = None,
+            spectrogram_clip: Optional[Tuple[int, int]] = None
+    ) -> Tuple[timestamps, npt.NDArray]:
+        """
+        Generate a certain section of the log_spectrogram given start and end
+        points.
+        Uses the logarithmic filtered spectrogram by default.
+
+        spectrogram_clip specifies the start and end of the frequency bands
+        index, useful for reducing ram usage and improving performance if you
+        don't need the whole range of frequency bands.
+
+        Parameters
+        ----------
+        start : float, optional
+            start time in seconds, default zero
+        end : float, optional
+            end time in seconds, default is end of file
+        spectrogram_clip : Tuple[int, int], optional
+            tuple of indexes. Frequency bands within these
+            indexes will be kept.
+
+        Returns
+        -------
+        start_end_spectrogram : Tuple[time_section, npt.NDArray]
+            exact start and end times of spectrogram, spectrogram
+        """
+        if start is None:
+            start = 0
+        if end is None:
+            end = self.signal.shape[0]
+        if spectrogram_clip is None:
+            spectrogram_clip = (10, 40)
+
+        start = self.get_frame(start)
+        end = self.get_frame(end)
+
+        if end - start <= 0:
+            raise AttributeError("The given end should be larger than the "
+                                 "start.")
+
+        spec = np.array(
+            madmom.audio.LogarithmicFilteredSpectrogram(
+                self.signal[start:end][:]
+            )
+        )[:, spectrogram_clip[0]:spectrogram_clip[1]]
+
+        return (self.frame_times[start], self.frame_times[end]), spec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 numpy~=1.24.2
 scipy==1.10.1
 git+https://github.com/CPJKU/madmom@main#egg=madmom
-partitura==1.2.2
+git+https://github.com/CPJKU/partitura@fix_248#egg=partitura
 tqdm==4.65.0
 python-dotenv==1.0.0
 filedate==2.0
 setuptools==67.7.1
 fastdtw~=0.3.4
+ffmpeg-python~=0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy~=1.24.2
 scipy==1.10.1
 git+https://github.com/CPJKU/madmom@main#egg=madmom
-git+https://github.com/iv-pil/partitura@featuredev#egg=partitura
+partitura==1.2.2
 tqdm==4.65.0
 python-dotenv==1.0.0
 filedate==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tqdm==4.65.0
 python-dotenv==1.0.0
 filedate==2.0
 setuptools==67.7.1
-dtw-python~=1.3.0
+fastdtw~=0.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy==1.10.1
 git+https://github.com/CPJKU/madmom@main#egg=madmom
 git+https://github.com/iv-pil/partitura@featuredev#egg=partitura
 tqdm==4.65.0
-ffmpeg-python==0.2.0
 python-dotenv==1.0.0
 filedate==2.0
-setuptools==67.6.1
+setuptools==67.7.1
+dtw-python~=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 import io
 import os
+
 from setuptools import setup
 
 # Package meta-data.


### PR DESCRIPTION
This pull request adds:
 - `R3CheckIntegrity.py` script that checks all split files 
 - `check_video_flac` function in `alignment.verification`
 - `load_file_audio` function that can load audio from a video directly into ram

Currently, there are two checks. A length check, `Verify.check_len` to make sure the files are close enough in length, and a spectrogram comparison, `Verify.check_spectrogram`, using DTW. 

If either of these fails the split is considered invalid.

The default values used when considering what "close enough" in length or DTW deviation come from my own testing. 

This pull request also introduces a new dependency, `dtw-python`.

Additionally, the Track object was moved into its own file, `utils.track` and extended to support automatically extracting audio from videos.